### PR TITLE
Fix the duplicated elevator in Endless Canyon when enabling New Horizons

### DIFF
--- a/TheOutsider/manifest.json
+++ b/TheOutsider/manifest.json
@@ -3,7 +3,7 @@
   "author": "Streetlights Behind the Trees",
   "name": "The Outsider",
   "uniqueName": "SBtT.TheOutsider",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "owmlVersion": "2.9.0",
   "conflicts": [ "orclecle.TranslationForTheOutsider" ]
 }

--- a/TheOutsiderFixes/BugFixPatches.cs
+++ b/TheOutsiderFixes/BugFixPatches.cs
@@ -51,7 +51,10 @@ namespace TheOutsiderFixes
                     if (NewHorizonsCompat.ShouldLoadOutsider)
                     {
                         _tuneStatureIslandColliderCoroutine = ModMain.Instance.StartCoroutine(TuneStatureIslandCollider());
-                        _fixEndlessCanyonElevatorCoroutine = ModMain.Instance.StartCoroutine(FixEndlessCanyonElevator());
+                        if (!NewHorizonsCompat.IsNHInstalled)
+                        {
+                            _fixEndlessCanyonElevatorCoroutine = ModMain.Instance.StartCoroutine(FixEndlessCanyonElevator());
+                        }
                         _fixDreamGravityinatorCoroutine = ModMain.Instance.StartCoroutine(FixDreamGravityinator());
                     }
                 }


### PR DESCRIPTION
This PR fixes #26 (actually, #26 includes not only the elevator duplication issue but also the elevator disappearance issue, but it cannot be reproduced, so I am targeting only the duplication one).

The issue is that the elevator in Endless Canyon is duplicated when New Horizons is enabled.
Historically, The Outsider copies the elevator in Endless Canyon into one in Friend's simulated house, but weirdly the cage of the copy source disappeared.
Thus, I made a patch: https://github.com/TRSasasusu/TranslationForTheOutsider/issues/22 , which copies the cage in Friend's simulated house into Endless Canyon.
However, if New Horizons exists, somehow, the copy by The Outsider completely seems to have succeeded.
As a result, there are two cages in Endless Canyon.

So, this PR disables the cage copy patch only when New Horizons is enabled.